### PR TITLE
ci: reduce dependency updating to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_prs: false
   autofix_commit_msg: "style: pre-commit fixes"
+  autoupdate_schedule: "monthly"
 
 exclude: ^.cruft.json|.copier-answers.yml$|old_scripts/.*|.vscode/.*
 


### PR DESCRIPTION
Dependabot and pre-commit CI will now check for dependency updates monthly instead of weekly. to reduce maintenance requirements