### PR TITLE
docs: add link to PegasusTools repo to header of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PegasusTools
+# [PegasusTools](https://github.com/PegasusPIC/pegasustools)
 
 [![Actions Status][actions-badge]][actions-link]
 [![pre-commit.ci status][pre-commit-badge]][pre-commit-link]


### PR DESCRIPTION
This way when you click the "PegasusTools" header in the docs in takes you back to the repo