### PR TITLE
fix: generalize .track.dat header check

### DIFF
--- a/src/pegasustools/loading_tracks.py
+++ b/src/pegasustools/loading_tracks.py
@@ -54,8 +54,6 @@ def _ascii_track_reader(file_path: Path, particle_id_max: int) -> pl.DataFrame:
             "track",
             "data",
             "for",
-            "particle",
-            "with",
         ]
         if header[:7] != fiducial_header_start:
             logger.critical(


### PR DESCRIPTION
Some new headers replace "particle" with "proton" so shortening the header check generalizes for both.