### PR TITLE
feat: load the meshblock locations when loading spectra files

### DIFF
--- a/docs/reading_pegasus_files.ipynb
+++ b/docs/reading_pegasus_files.ipynb
@@ -206,6 +206,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The `x1min`, `x1max`, `x2min`, `x2max`, `x3min`, and `x3max` meshblock location data is also loaded and stored in the `PegasusSpectralData.meshblock_locations` member variable which is a Polars DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectra_data.meshblock_locations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "At this point you have a `PegasusSpectralData` that contains all the information in the original spectra file but now in a numpy array that is easy to manipulate and perform additional postprocessing. "
    ]
   },


### PR DESCRIPTION
This adds a member variable, meshblock_locations, to PegasusSpectralData that contains all of the meshblock location information. This also includes tests and documentation for the new feature.

Resolves #74